### PR TITLE
Fix edge case

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ export default function pointInPolygon(p, polygon) {
 
             if (v1 === 0 && v2 === 0) {
                 if ((u2 <= 0 && u1 >= 0) || (u1 <= 0 && u2 >= 0)) return 0
-            } else if ((v2 >= 0 && v1 < 0) || (v2 < 0 && v1 >= 0)) {
+            } else if ((v2 >= 0 && v1 <= 0) || (v2 <= 0 && v1 >= 0)) {
                 f = orient2d(u1, u2, v1, v2, 0, 0)
                 if (f === 0) return 0
                 if ((f > 0 && v2 > 0 && v1 <= 0) || (f < 0 && v2 <= 0 && v1 > 0)) k++

--- a/test/test.test.js
+++ b/test/test.test.js
@@ -63,3 +63,38 @@ test('error is thrown when not the same first and last coords', () => {
 
     expect(() => inside([1, 1], poly)).toThrowError(/First and last/)
 });
+
+
+const polygonDiamond = [[[-1, 0], [0, -1], [1, 0], [0, 1], [-1, 0]]];
+
+test('is inside diamond', () => {
+    expect(inside([0, 0], polygonDiamond)).toBe(true)
+});
+
+test('is outside diamond', () => {
+    expect(inside([1, 1], polygonDiamond)).toBe(false)
+});
+
+test('is on left vertex', () => {
+    expect(inside([-1, 0], polygonDiamond)).toBe(0)
+});
+
+test('is on bottom vertex', () => {
+    expect(inside([0, -1], polygonDiamond)).toBe(0)
+});
+
+test('is on right vertex', () => {
+    expect(inside([1, 0], polygonDiamond)).toBe(0)
+});
+
+test('is on top vertex', () => {
+    expect(inside([0, 1], polygonDiamond)).toBe(0)
+});
+
+test('is on bottom left edge', () => {
+    expect(inside([-0.5, -0.5], polygonDiamond)).toBe(0)
+});
+
+test('is on bottom right edge', () => {
+    expect(inside([0.5, -0.5], polygonDiamond)).toBe(0)
+});


### PR DESCRIPTION
This pull request should solve the problem I mentioned in #24, and also gives the expected results on the data from #23 and #22.

I noticed while reading the paper mentioned in the README that the cases `v2 > 0 and v1 == 0` and `v1 > 0 and v2 == 0` did not pass the condition as written in the code.
I modified the condition to take these cases into account, and also added some new tests.